### PR TITLE
UDP support + system clock interception

### DIFF
--- a/msim-tokio/Cargo.toml
+++ b/msim-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio"
-version = "1.20.1"
+version = "1.21.1"
 edition = "2021"
 authors = ["Runji Wang <wangrunji0408@163.com>", "Mysten Labs <build@mystenlabs.com>"]
 description = "The `tokio` simulator on msim."
@@ -63,7 +63,8 @@ msim = { version = "0.1.0", path = "../msim" }
 
 [dependencies]
 tracing = "0.1"
-real_tokio = { git = "https://github.com/mystenmark/tokio-madsim-fork.git", rev = "8ca4c94029ac1b7c8342720820e6100e9f31a372", package = "real_tokio", features = ["full"] }
+
+real_tokio = { git = "https://github.com/mystenmark/tokio-madsim-fork.git", rev = "53757350d27e3743ec4b024ac18c2d6a2717efe0", package = "real_tokio", features = ["full"] }
 bytes = { version = "1.1" }
 futures = { version = "0.3.0", features = ["async-await"] }
 mio = { version = "0.8.1" }

--- a/msim-tokio/src/lib.rs
+++ b/msim-tokio/src/lib.rs
@@ -19,6 +19,7 @@ mod sim {
     #[cfg(all(feature = "rt", feature = "macros"))]
     pub use msim::{sim_test, test};
 
+    pub mod io;
     pub mod net;
     mod udp;
     pub mod unix;
@@ -27,13 +28,13 @@ mod sim {
     // TODO: simulate `fs`
     #[cfg(feature = "fs")]
     pub use real_tokio::fs;
+    pub use real_tokio::pin;
     #[cfg(feature = "process")]
     pub use real_tokio::process;
     #[cfg(feature = "signal")]
     pub use real_tokio::signal;
     #[cfg(feature = "sync")]
     pub use real_tokio::sync;
-    pub use real_tokio::{io, pin};
     #[cfg(feature = "macros")]
     pub use real_tokio::{join, main, select, try_join};
 }

--- a/msim-tokio/src/sim/io.rs
+++ b/msim-tokio/src/sim/io.rs
@@ -1,0 +1,303 @@
+pub use real_tokio::io::*;
+
+pub mod unix {
+    use futures::{future::poll_fn, ready};
+    use msim::net::get_endpoint_from_socket;
+    use msim::rand::{prelude::thread_rng, Rng};
+    use msim::time::{Duration, Instant, TimeHandle};
+    use real_tokio::io;
+    use real_tokio::io::Interest;
+    use std::os::unix::io::{AsRawFd, RawFd};
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::{task::Context, task::Poll};
+
+    /// Reimplementation of AsyncFd for simulator.
+    /// Only works with UDP sockets right now.
+    pub struct AsyncFd<T: AsRawFd> {
+        inner: Option<T>,
+        next_ready_write_nanos: AtomicU64,
+    }
+
+    #[must_use = "You must explicitly choose whether to clear the readiness state by calling a method on ReadyGuard"]
+    pub struct AsyncFdReadyGuard<'a, T: AsRawFd> {
+        async_fd: &'a AsyncFd<T>,
+    }
+
+    #[must_use = "You must explicitly choose whether to clear the readiness state by calling a method on ReadyGuard"]
+    pub struct AsyncFdReadyMutGuard<'a, T: AsRawFd> {
+        async_fd: &'a mut AsyncFd<T>,
+    }
+
+    const ALL_INTEREST: Interest = Interest::READABLE.add(Interest::WRITABLE);
+
+    impl<T: AsRawFd> AsyncFd<T> {
+        #[inline]
+        pub fn new(inner: T) -> io::Result<Self>
+        where
+            T: AsRawFd,
+        {
+            Self::with_interest(inner, ALL_INTEREST)
+        }
+
+        #[inline]
+        pub fn with_interest(inner: T, interest: Interest) -> io::Result<Self>
+        where
+            T: AsRawFd,
+        {
+            Self::new_with_handle_and_interest(inner, interest)
+        }
+
+        pub(crate) fn new_with_handle_and_interest(
+            inner: T,
+            _interest: Interest,
+        ) -> io::Result<Self> {
+            Ok(AsyncFd {
+                inner: Some(inner),
+                next_ready_write_nanos: AtomicU64::new(0),
+            })
+        }
+
+        #[inline]
+        pub fn get_ref(&self) -> &T {
+            self.inner.as_ref().unwrap()
+        }
+
+        #[inline]
+        pub fn get_mut(&mut self) -> &mut T {
+            self.inner.as_mut().unwrap()
+        }
+
+        fn take_inner(&mut self) -> Option<T> {
+            self.inner.take()
+        }
+
+        pub fn into_inner(mut self) -> T {
+            self.take_inner().unwrap()
+        }
+
+        pub fn poll_read_ready<'a>(
+            &'a self,
+            cx: &mut Context<'_>,
+        ) -> Poll<io::Result<AsyncFdReadyGuard<'a, T>>> {
+            ready!(self.poll_ready_ready_impl(cx))?;
+            Ok(AsyncFdReadyGuard { async_fd: self }).into()
+        }
+
+        pub fn poll_read_ready_mut<'a>(
+            &'a mut self,
+            cx: &mut Context<'_>,
+        ) -> Poll<io::Result<AsyncFdReadyMutGuard<'a, T>>> {
+            ready!(self.poll_ready_ready_impl(cx))?;
+            Ok(AsyncFdReadyMutGuard { async_fd: self }).into()
+        }
+
+        fn poll_ready_ready_impl(&self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            let ep = match get_endpoint_from_socket(self.inner.as_ref().unwrap().as_raw_fd()) {
+                Err(err) => return Poll::Ready(Err(err)),
+                Ok(ep) => ep,
+            };
+            let port = ep.udp_tag();
+            match port {
+                Err(err) => Err(err).into(),
+                Ok(port) => match ep.recv_ready(cx, port) {
+                    Err(err) => Err(err).into(),
+                    Ok(true) => Ok(()).into(),
+                    Ok(false) => Poll::Pending,
+                },
+            }
+        }
+
+        pub fn poll_write_ready<'a>(
+            &'a self,
+            cx: &mut Context<'_>,
+        ) -> Poll<io::Result<AsyncFdReadyGuard<'a, T>>> {
+            ready!(self.poll_write_ready_impl(cx))?;
+            Ok(AsyncFdReadyGuard { async_fd: self }).into()
+        }
+
+        pub fn poll_write_ready_mut<'a>(
+            &'a mut self,
+            cx: &mut Context<'_>,
+        ) -> Poll<io::Result<AsyncFdReadyMutGuard<'a, T>>> {
+            ready!(self.poll_write_ready_impl(cx))?;
+            Ok(AsyncFdReadyMutGuard { async_fd: self }).into()
+        }
+
+        fn poll_write_ready_impl(&self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            let handle = TimeHandle::current();
+            let now_nanos: u64 = handle.elapsed().as_nanos().try_into().unwrap();
+            let ready = self.next_ready_write_nanos.load(Ordering::Relaxed);
+            if now_nanos >= ready {
+                self.next_ready_write_nanos
+                    .store(now_nanos + thread_rng().gen_range(0..50), Ordering::Relaxed);
+
+                Ok(()).into()
+            } else {
+                handle.wake_at(
+                    Instant::now() + Duration::from_nanos(ready - now_nanos),
+                    cx.waker().clone(),
+                );
+                Poll::Pending
+            }
+        }
+
+        async fn readiness(&self, interest: Interest) -> io::Result<AsyncFdReadyGuard<'_, T>> {
+            match interest {
+                Interest::READABLE => poll_fn(|cx| self.poll_read_ready(cx)).await,
+                Interest::WRITABLE => poll_fn(|cx| self.poll_write_ready(cx)).await,
+                _ => unimplemented!("unhandled interested {:?}", interest),
+            }
+        }
+
+        async fn readiness_mut(
+            &mut self,
+            interest: Interest,
+        ) -> io::Result<AsyncFdReadyMutGuard<'_, T>> {
+            let shared_self = &*self;
+            match interest {
+                Interest::READABLE => poll_fn(|cx| shared_self.poll_ready_ready_impl(cx)).await?,
+                Interest::WRITABLE => poll_fn(|cx| shared_self.poll_write_ready_impl(cx)).await?,
+                _ => unimplemented!("unhandled interested {:?}", interest),
+            }
+
+            Ok(AsyncFdReadyMutGuard { async_fd: self }).into()
+        }
+
+        #[allow(clippy::needless_lifetimes)] // The lifetime improves rustdoc rendering.
+        pub async fn readable<'a>(&'a self) -> io::Result<AsyncFdReadyGuard<'a, T>> {
+            self.readiness(Interest::READABLE).await
+        }
+
+        #[allow(clippy::needless_lifetimes)] // The lifetime improves rustdoc rendering.
+        pub async fn readable_mut<'a>(&'a mut self) -> io::Result<AsyncFdReadyMutGuard<'a, T>> {
+            self.readiness_mut(Interest::READABLE).await
+        }
+
+        #[allow(clippy::needless_lifetimes)] // The lifetime improves rustdoc rendering.
+        pub async fn writable<'a>(&'a self) -> io::Result<AsyncFdReadyGuard<'a, T>> {
+            self.readiness(Interest::WRITABLE).await
+        }
+
+        #[allow(clippy::needless_lifetimes)] // The lifetime improves rustdoc rendering.
+        pub async fn writable_mut<'a>(&'a mut self) -> io::Result<AsyncFdReadyMutGuard<'a, T>> {
+            self.readiness_mut(Interest::WRITABLE).await
+        }
+    }
+
+    impl<T: AsRawFd> AsRawFd for AsyncFd<T> {
+        fn as_raw_fd(&self) -> RawFd {
+            self.inner.as_ref().unwrap().as_raw_fd()
+        }
+    }
+
+    impl<T: std::fmt::Debug + AsRawFd> std::fmt::Debug for AsyncFd<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("AsyncFd")
+                .field("inner", &self.inner)
+                .finish()
+        }
+    }
+
+    impl<T: AsRawFd> Drop for AsyncFd<T> {
+        fn drop(&mut self) {
+            let _ = self.take_inner();
+        }
+    }
+
+    impl<'a, Inner: AsRawFd> AsyncFdReadyGuard<'a, Inner> {
+        pub fn clear_ready(&mut self) {}
+
+        pub fn retain_ready(&mut self) {
+            // no-op
+        }
+
+        // Alias for old name in 0.x
+        #[cfg_attr(docsrs, doc(alias = "with_io"))]
+        pub fn try_io<R>(
+            &mut self,
+            f: impl FnOnce(&'a AsyncFd<Inner>) -> io::Result<R>,
+        ) -> Result<io::Result<R>, TryIoError> {
+            let result = f(self.async_fd);
+
+            if let Err(e) = result.as_ref() {
+                if e.kind() == io::ErrorKind::WouldBlock {
+                    self.clear_ready();
+                }
+            }
+
+            match result {
+                Err(err) if err.kind() == io::ErrorKind::WouldBlock => Err(TryIoError(())),
+                result => Ok(result),
+            }
+        }
+
+        pub fn get_ref(&self) -> &'a AsyncFd<Inner> {
+            self.async_fd
+        }
+
+        pub fn get_inner(&self) -> &'a Inner {
+            self.get_ref().get_ref()
+        }
+    }
+
+    impl<'a, Inner: AsRawFd> AsyncFdReadyMutGuard<'a, Inner> {
+        pub fn clear_ready(&mut self) {}
+
+        pub fn retain_ready(&mut self) {
+            // no-op
+        }
+
+        pub fn try_io<R>(
+            &mut self,
+            f: impl FnOnce(&mut AsyncFd<Inner>) -> io::Result<R>,
+        ) -> Result<io::Result<R>, TryIoError> {
+            let result = f(self.async_fd);
+
+            if let Err(e) = result.as_ref() {
+                if e.kind() == io::ErrorKind::WouldBlock {
+                    self.clear_ready();
+                }
+            }
+
+            match result {
+                Err(err) if err.kind() == io::ErrorKind::WouldBlock => Err(TryIoError(())),
+                result => Ok(result),
+            }
+        }
+
+        pub fn get_ref(&self) -> &AsyncFd<Inner> {
+            self.async_fd
+        }
+
+        pub fn get_mut(&mut self) -> &mut AsyncFd<Inner> {
+            self.async_fd
+        }
+
+        pub fn get_inner(&self) -> &Inner {
+            self.get_ref().get_ref()
+        }
+
+        pub fn get_inner_mut(&mut self) -> &mut Inner {
+            self.get_mut().get_mut()
+        }
+    }
+
+    impl<'a, T: std::fmt::Debug + AsRawFd> std::fmt::Debug for AsyncFdReadyGuard<'a, T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("ReadyGuard")
+                .field("async_fd", &self.async_fd)
+                .finish()
+        }
+    }
+
+    impl<'a, T: std::fmt::Debug + AsRawFd> std::fmt::Debug for AsyncFdReadyMutGuard<'a, T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("MutReadyGuard")
+                .field("async_fd", &self.async_fd)
+                .finish()
+        }
+    }
+
+    #[derive(Debug)]
+    pub struct TryIoError(());
+}

--- a/msim-tokio/src/sim/net.rs
+++ b/msim-tokio/src/sim/net.rs
@@ -321,7 +321,7 @@ impl TcpStream {
 
         // read the remote port back
         trace!(
-            "reading remote port from server {} {}",
+            "awaiting remote port from server {} {}",
             remote_sock,
             local_port
         );
@@ -330,6 +330,11 @@ impl TcpStream {
         debug_assert_eq!(from, remote_sock);
         // finish initializing state
         state.remote_port = Message::new(msg).unwrap_port();
+        trace!(
+            "received remote port from server {} <- {}",
+            state.remote_sock,
+            from
+        );
         Ok(Self::new(state))
     }
 
@@ -695,13 +700,13 @@ mod tests {
     use super::{OwnedReadHalf, OwnedWriteHalf, TcpListener, TcpStream};
     use bytes::{BufMut, BytesMut};
     use futures::join;
-    use tracing::trace;
     use msim::{rand, rand::RngCore, runtime::Runtime};
     use real_tokio::{
         io::{AsyncReadExt, AsyncWriteExt},
         sync::Barrier,
     };
     use std::{net::SocketAddr, sync::Arc};
+    use tracing::trace;
 
     async fn test_stream_read(mut stream: OwnedReadHalf) {
         trace!("test_stream_read");

--- a/msim/Cargo.toml
+++ b/msim/Cargo.toml
@@ -41,6 +41,7 @@ naive-timer = "0.2"
 tokio = { git = "https://github.com/mystenmark/tokio-madsim-fork.git", rev = "8ca4c94029ac1b7c8342720820e6100e9f31a372", package = "real_tokio", features = ["full"] }
 tokio-util = { git = "https://github.com/mystenmark/tokio-madsim-fork.git", rev = "8ca4c94029ac1b7c8342720820e6100e9f31a372", features = ["full"] }
 toml = "0.5"
+socket2 = "0.4"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/msim/Cargo.toml
+++ b/msim/Cargo.toml
@@ -38,15 +38,15 @@ async-task = "4"
 downcast-rs = "1.2"
 libc = "0.2"
 naive-timer = "0.2"
-tokio = { git = "https://github.com/mystenmark/tokio-madsim-fork.git", rev = "8ca4c94029ac1b7c8342720820e6100e9f31a372", package = "real_tokio", features = ["full"] }
-tokio-util = { git = "https://github.com/mystenmark/tokio-madsim-fork.git", rev = "8ca4c94029ac1b7c8342720820e6100e9f31a372", features = ["full"] }
+tokio = { git = "https://github.com/mystenmark/tokio-madsim-fork.git", rev = "53757350d27e3743ec4b024ac18c2d6a2717efe0", package = "real_tokio", features = ["full"] }
+tokio-util = { git = "https://github.com/mystenmark/tokio-madsim-fork.git", rev = "53757350d27e3743ec4b024ac18c2d6a2717efe0", features = ["full"] }
 toml = "0.5"
 socket2 = "0.4"
 
 [dev-dependencies]
 criterion = "0.3"
 structopt = "0.3"
-tokio = { git = "https://github.com/mystenmark/tokio-madsim-fork.git", rev = "8ca4c94029ac1b7c8342720820e6100e9f31a372", package = "real_tokio", features = ["full"] }
+tokio = { git = "https://github.com/mystenmark/tokio-madsim-fork.git", rev = "53757350d27e3743ec4b024ac18c2d6a2717efe0", package = "real_tokio", features = ["full"] }
 
 [[bench]]
 name = "rpc"

--- a/msim/src/sim/intercept.rs
+++ b/msim/src/sim/intercept.rs
@@ -1,0 +1,55 @@
+use std::cell::Cell;
+use tracing::info;
+
+thread_local! {
+    static INTERCEPTS_ENABLED: Cell<bool> = Cell::new(false);
+}
+
+// This is called at the beginning of the test thread so that clock calls inside the test are
+// deterministic. Other threads (e.g. any thread doing real io) are unaffected.
+pub(crate) fn enable_intercepts(e: bool) {
+    let cur_thread = std::thread::current().id();
+    info!(
+        "{} library call intercepts on thread {:?}",
+        if e { "enabling" } else { "disabling" },
+        cur_thread
+    );
+    INTERCEPTS_ENABLED.with(|enabled| enabled.set(e))
+}
+
+pub(crate) fn intercepts_enabled() -> bool {
+    INTERCEPTS_ENABLED.with(|e| e.get())
+}
+
+/// Cache and call a library function via dlsym()
+#[macro_export]
+macro_rules! define_sys_interceptor {
+
+    (fn $name:ident ( $($param:ident : $type:ty),* $(,)? ) -> $ret:ty { $($body:tt)+ }) => {
+
+        #[no_mangle]
+        #[inline(never)]
+        unsafe extern "C" fn $name ( $($param: $type),* ) -> $ret {
+            {
+                lazy_static::lazy_static! {
+                    static ref NEXT_DL_SYM: unsafe extern "C" fn ( $($param: $type),* ) -> $ret = unsafe {
+
+                        let fn_name = stringify!($name);
+                        let fn_name_c = std::ffi::CString::new(fn_name).unwrap();
+
+                        let ptr = libc::dlsym(libc::RTLD_NEXT, fn_name_c.as_ptr() as _);
+                        assert!(!ptr.is_null());
+                        std::mem::transmute(ptr)
+                    };
+                }
+
+                if !crate::sim::intercept::intercepts_enabled() {
+                    return NEXT_DL_SYM($($param),*);
+                }
+            }
+
+            $($body)*
+
+        }
+    }
+}

--- a/msim/src/sim/mod.rs
+++ b/msim/src/sim/mod.rs
@@ -10,6 +10,7 @@ pub use msim_macros::{main, sim_test, test};
 pub mod collections;
 mod config;
 pub mod fs;
+mod intercept;
 pub mod net;
 #[cfg_attr(docsrs, doc(cfg(msim)))]
 pub mod plugin;

--- a/msim/src/sim/net/mod.rs
+++ b/msim/src/sim/net/mod.rs
@@ -35,13 +35,13 @@
 //! runtime.block_on(f);
 //! ```
 
-use tracing::*;
 use std::{
     collections::{hash_map::Entry, HashMap},
     io,
     net::{IpAddr, Ipv4Addr, SocketAddr, ToSocketAddrs},
     sync::{Arc, Mutex},
 };
+use tracing::*;
 
 pub use self::network::{Config, Stat};
 use self::network::{Network, Payload};
@@ -315,7 +315,7 @@ impl Endpoint {
     /// It is provided for use by other simulators.
     #[cfg_attr(docsrs, doc(cfg(msim)))]
     pub async fn send_to_raw(&self, dst: SocketAddr, tag: u64, data: Payload) -> io::Result<()> {
-        trace!("send_to_raw {} -> {}, {}", self.addr, dst, tag);
+        trace!("send_to_raw {} -> {}, {:x}", self.addr, dst, tag);
         self.net
             .network
             .lock()
@@ -331,6 +331,7 @@ impl Endpoint {
     /// It is provided for use by other simulators.
     #[cfg_attr(docsrs, doc(cfg(msim)))]
     pub async fn recv_from_raw(&self, tag: u64) -> io::Result<(Payload, SocketAddr)> {
+        trace!("awaiting recv: {} tag={:x}", self.addr, tag);
         let recver = self
             .net
             .network
@@ -342,7 +343,7 @@ impl Endpoint {
             .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "network is down"))?;
         self.net.rand_delay().await;
 
-        trace!("recv: {} <- {}, tag={}", self.addr, msg.from, msg.tag);
+        trace!("recv: {} <- {}, tag={:x}", self.addr, msg.from, msg.tag);
         Ok((msg.data, msg.from))
     }
 

--- a/msim/src/sim/net/mod.rs
+++ b/msim/src/sim/net/mod.rs
@@ -40,13 +40,14 @@ use std::{
     io,
     net::{IpAddr, Ipv4Addr, SocketAddr, ToSocketAddrs},
     sync::{Arc, Mutex},
+    task::Context,
 };
 use tracing::*;
 
 pub use self::network::{Config, Stat};
 use self::network::{Network, Payload};
 use crate::{
-    plugin,
+    define_bypass, define_sys_interceptor, plugin,
     rand::{GlobalRng, Rng},
     task::NodeId,
     time::{Duration, TimeHandle},
@@ -63,10 +64,486 @@ pub mod rpc;
 #[cfg_attr(docsrs, doc(cfg(msim)))]
 pub struct NetSim {
     network: Mutex<Network>,
+    host_state: Mutex<HostNetworkState>,
     rand: GlobalRng,
     time: TimeHandle,
     next_port_map: Mutex<HashMap<NodeId, u32>>,
 }
+
+#[derive(Debug)]
+struct FileDes(libc::c_int);
+
+impl Drop for FileDes {
+    fn drop(&mut self) {
+        unsafe {
+            assert_eq!(bypass_close(self.0), 0);
+        }
+    }
+}
+
+#[derive(Debug)]
+struct SocketState {
+    ty: libc::c_int,
+    _placeholder_file: FileDes,
+    endpoint: Option<Arc<Endpoint>>,
+}
+
+#[derive(Default)]
+struct HostNetworkState {
+    sockets: HashMap<(NodeId, libc::c_int), SocketState>,
+}
+
+impl HostNetworkState {
+    fn add_socket(fd: libc::c_int, socket: SocketState) {
+        let net = plugin::simulator::<NetSim>();
+        let node_id = plugin::node();
+        let mut host_state = net.host_state.lock().unwrap();
+        trace!("registering socket {}.{} -> {:?}", node_id, fd, socket);
+
+        assert!(
+            host_state.sockets.insert((node_id, fd), socket).is_none(),
+            "duplicate socket"
+        );
+    }
+
+    fn bind_socket(fd: libc::c_int, addr: SocketAddr) -> libc::c_int {
+        let net = plugin::simulator::<NetSim>();
+        let node_id = plugin::node();
+        let mut host_state = net.host_state.lock().unwrap();
+
+        trace!("binding socket {}.{} -> {:?}", node_id, fd, addr);
+
+        let socket = host_state.sockets.get_mut(&(node_id, fd)).unwrap();
+        assert!(socket.endpoint.is_none(), "socket already bound");
+        socket.endpoint = Some(Arc::new(Endpoint::bind_sync(addr).unwrap()));
+        0
+    }
+
+    fn close_socket(fd: libc::c_int) -> bool {
+        let net = plugin::simulator::<NetSim>();
+        let node_id = plugin::node();
+        let mut host_state = net.host_state.lock().unwrap();
+
+        let res = host_state.sockets.remove(&(node_id, fd)).is_some();
+        if res {
+            trace!("closing socket {}.{}", node_id, fd);
+        }
+        res
+    }
+
+    fn get_socket_addr(fd: libc::c_int) -> Option<SocketAddr> {
+        let net = plugin::simulator::<NetSim>();
+        let node_id = plugin::node();
+        let host_state = net.host_state.lock().unwrap();
+
+        let socket = host_state.sockets.get(&(node_id, fd))?;
+        socket.endpoint.as_ref().map(|ep| ep.local_addr().unwrap())
+    }
+
+    fn with_socket<T>(fd: libc::c_int, cb: impl Fn(&mut SocketState) -> T) -> io::Result<T> {
+        let net = plugin::simulator::<NetSim>();
+        let node_id = plugin::node();
+        let mut host_state = net.host_state.lock().unwrap();
+        let socket = host_state
+            .sockets
+            .get_mut(&(node_id, fd))
+            .ok_or_else(|| io::Error::new(io::ErrorKind::NotConnected, "no such socket"))?;
+        Ok(cb(socket))
+    }
+}
+
+/// Get the Endpoint of a bound socket.
+pub fn get_endpoint_from_socket(fd: libc::c_int) -> io::Result<Arc<Endpoint>> {
+    HostNetworkState::with_socket(fd, |socket| socket.endpoint.as_ref().map(|ep| ep.clone()))?
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotConnected, "socket has not been bound"))
+}
+
+define_bypass!(bypass_close, fn close(fd: libc::c_int) -> libc::c_int);
+
+define_sys_interceptor!(
+    fn close(fd: libc::c_int) -> libc::c_int {
+        if HostNetworkState::close_socket(fd) {
+            return 0;
+        }
+        trace!("forwarding close({}) to libc", fd);
+        NEXT_DL_SYM(fd)
+    }
+);
+
+#[cfg(target_os = "macos")]
+unsafe fn set_errno(err: libc::c_int) {
+    *libc::__error() = err;
+}
+
+#[cfg(target_os = "linux")]
+unsafe fn set_errno(err: libc::c_int) {
+    *libc::__errno_location() = err;
+}
+
+define_sys_interceptor!(
+    fn bind(
+        sock_fd: libc::c_int,
+        sock_addr: *const libc::sockaddr,
+        addr_len: libc::socklen_t,
+    ) -> libc::c_int {
+        let socket_addr = socket2::SockAddr::init(|storage, len| {
+            std::ptr::copy_nonoverlapping(
+                sock_addr as *const u8,
+                storage as *mut u8,
+                std::cmp::min(*len, addr_len) as usize,
+            );
+            Ok(())
+        })
+        .unwrap()
+        .1
+        .as_socket()
+        .unwrap();
+
+        if socket_addr.is_ipv6() {
+            warn!("ipv6 not supported in simulator");
+            set_errno(libc::EADDRNOTAVAIL);
+            return -1;
+        }
+
+        HostNetworkState::bind_socket(sock_fd, socket_addr)
+    }
+);
+
+define_sys_interceptor!(
+    fn connect(
+        socket: libc::c_int,
+        address: *const libc::sockaddr,
+        len: libc::socklen_t,
+    ) -> libc::c_int {
+        todo!();
+    }
+);
+
+define_sys_interceptor!(
+    fn socket(domain: libc::c_int, ty: libc::c_int, protocol: libc::c_int) -> libc::c_int {
+        assert!(
+            domain == libc::AF_INET || domain == libc::AF_INET6,
+            "only ip4 sockets are currently supported"
+        );
+
+        if protocol != 0 {
+            warn!("socket(): non-zero protocol ignored - application intent may not be respected");
+        }
+
+        // Allocate a new file descriptor - it will never be used. We don't want to allocate fds
+        // ourselves because the program may allocate an fd from some other means (like open())
+        // which could collide with any descriptor we choose.
+        let fd = libc::dup(0);
+
+        let socket = SocketState {
+            ty,
+            _placeholder_file: FileDes(fd),
+            endpoint: None,
+        };
+
+        HostNetworkState::add_socket(fd, socket);
+
+        fd
+    }
+);
+
+define_sys_interceptor!(
+    fn getsockname(
+        socket: libc::c_int,
+        address: *mut libc::sockaddr,
+        address_len: *mut libc::socklen_t,
+    ) -> libc::c_int {
+        trace!("getsockname({})", socket);
+        // getsockname() on an un-bound socket does not actually return an error - instead it has
+        // unspecified behavior. But we can just panic, since doing this would be a bug anyway.
+        let addr: socket2::SockAddr = HostNetworkState::get_socket_addr(socket)
+            .expect("getsockname() on un-bound socket")
+            .into();
+
+        let len = std::cmp::min(*address_len as usize, addr.len() as usize);
+
+        std::ptr::copy_nonoverlapping(addr.as_ptr() as *const u8, address as *mut u8, len);
+
+        let address_len = &mut *address_len;
+        *address_len = addr.len();
+
+        0
+    }
+);
+
+define_sys_interceptor!(
+    fn setsockopt(
+        socket: libc::c_int,
+        level: libc::c_int,
+        name: libc::c_int,
+        value: *const libc::c_void,
+        option_len: libc::socklen_t,
+    ) -> libc::c_int {
+        trace!("setsockopt({}, {}, {})", socket, level, name);
+        match (level, name) {
+            (libc::IPPROTO_IPV6, _) => unimplemented!("ipv6 not supported"),
+
+            // called by rust std::net::TcpListener::bind
+            // No need to actually emulate SO_REUSEADDR behavior (for now).
+            (libc::SOL_SOCKET, libc::SO_REUSEADDR) => 0,
+
+            // call by std::net::TcpStream::set_ttl
+            (libc::IPPROTO_IP, libc::IP_TTL) => 0,
+
+            // called by rust std::net::UdpSocket::bind
+            #[cfg(target_os = "macos")]
+            (libc::SOL_SOCKET, libc::SO_NOSIGPIPE) => 0,
+
+            // Call by quinn, no need to emulate (for now)
+            (libc::IPPROTO_IP, libc::IP_RECVTOS) => 0,
+            (libc::IPPROTO_IP, libc::IP_PKTINFO) => 0,
+
+            // The simulator never fragments or anything like that, so there is no need to simulate
+            // this option.
+            #[cfg(target_os = "linux")]
+            (libc::IPPROTO_IP, libc::IP_MTU_DISCOVER) => 0,
+
+            // simulator doesn't simulate GRO/GSO
+            #[cfg(target_os = "linux")]
+            (libc::SOL_UDP, libc::UDP_GRO) => -1,
+            #[cfg(target_os = "linux")]
+            (libc::SOL_UDP, libc::UDP_SEGMENT) => -1,
+
+            _ => {
+                warn!("unhandled socket option {} {}", level, name);
+                0
+            }
+        }
+    }
+);
+
+define_sys_interceptor!(
+    fn send(
+        sockfd: libc::c_int,
+        buf: *const libc::c_void,
+        len: libc::size_t,
+        flags: libc::c_int,
+    ) -> libc::ssize_t {
+        unimplemented!("simulator error: send() should have been handled by tokio");
+    }
+);
+
+define_sys_interceptor!(
+    fn sendto(
+        sockfd: libc::c_int,
+        buf: *const libc::c_void,
+        len: libc::size_t,
+        flags: libc::c_int,
+        dest_addr: *const libc::sockaddr,
+        addrlen: libc::socklen_t,
+    ) -> libc::ssize_t {
+        unimplemented!("simulator error: sendto() should have been handled by tokio");
+    }
+);
+
+enum UDPMessage {
+    Payload(Vec<u8>),
+}
+
+impl UDPMessage {
+    fn payload(v: Vec<u8>) -> Box<UDPMessage> {
+        Box::new(UDPMessage::Payload(v))
+    }
+
+    fn into_payload(self) -> Vec<u8> {
+        match self {
+            Self::Payload(v) => v,
+        }
+    }
+}
+
+unsafe fn msg_hdr_to_socket(msg: &libc::msghdr) -> SocketAddr {
+    socket2::SockAddr::init(|storage, len| {
+        std::ptr::copy_nonoverlapping(
+            msg.msg_name as *const u8,
+            storage as *mut u8,
+            std::cmp::min(*len, msg.msg_namelen) as usize,
+        );
+        Ok(())
+    })
+    .unwrap()
+    .1
+    .as_socket()
+    .unwrap()
+}
+
+unsafe fn send_impl(
+    socket: &mut SocketState,
+    dst_addr: &SocketAddr,
+    flags: libc::c_int,
+    iov: &libc::iovec,
+) -> libc::ssize_t {
+    assert_eq!(
+        socket.ty,
+        libc::SOCK_DGRAM,
+        "only UDP is supported in sendmsg/sendmmsg"
+    );
+
+    if flags != 0 {
+        warn!("unsupported flags to sendmsg/sendmmsg: {:x}", flags);
+    }
+
+    // TODO: we are not currently emulating control msgs, such as IP_PKTINFO -
+    // QUIC relies on this in situations where a socket is bound to 0.0.0.0 and there are multiple
+    // interfaces/ip addresses. However, simulated nodes don't have multiple IPs, so this doesn't
+    // affect us.
+    let slice = std::slice::from_raw_parts(iov.iov_base as *const u8, iov.iov_len);
+    let msg = UDPMessage::payload(slice.into());
+
+    // If we need to handle sending from unconnected sockets, we can make an ephemeral
+    // endpoint.
+    let ep = socket
+        .endpoint
+        .as_ref()
+        .expect("sendmsg on unconnected sockets not supported");
+
+    ep.send_to_raw_sync(*dst_addr, dst_addr.port().into(), msg);
+
+    slice.len() as libc::ssize_t
+}
+
+define_sys_interceptor!(
+    fn sendmsg(sockfd: libc::c_int, msg: *const libc::msghdr, flags: libc::c_int) -> libc::ssize_t {
+        HostNetworkState::with_socket(sockfd, |socket| {
+            let msg = &*msg;
+            let dst_addr = msg_hdr_to_socket(msg);
+
+            assert_eq!(msg.msg_iovlen, 1, "scatter/gather unsupported");
+
+            let iov = &*msg.msg_iov;
+
+            send_impl(socket, &dst_addr, flags, iov)
+        })
+        .unwrap_or_else(|e| {
+            trace!("error: {}", e);
+            set_errno(libc::EADDRNOTAVAIL);
+            -1
+        })
+    }
+);
+
+#[cfg(target_os = "linux")]
+define_sys_interceptor!(
+    fn sendmmsg(
+        sockfd: libc::c_int,
+        msgvec: *mut libc::mmsghdr,
+        vlen: libc::c_uint,
+        flags: libc::c_int,
+    ) -> libc::c_int {
+        HostNetworkState::with_socket(sockfd, |socket| {
+            let msgvec = &mut *msgvec;
+            let msgs = std::slice::from_raw_parts(msgvec.msg_hdr, msgvec.msg_len);
+
+            for msg in msgs {
+                let dst_addr = msg_hdr_to_socket(msg.msg_hdr);
+                assert_eq!(msg.msg_hdr.msg_iovlen, 1, "scatter/gather unsupported");
+                let iov = &*msg.msg_hdr.msg_iov;
+
+                msg.msg_len = send_impl(socket, &dst_addr, flags, iov);
+            }
+            msgs.len()
+        })
+        .unwrap_or_else(|e| {
+            trace!("socket not found: {}", e);
+            set_errno(libc::EADDRNOTAVAIL);
+            -1
+        })
+    }
+);
+
+type CResult<T> = Result<T, (T, libc::c_int)>;
+
+define_sys_interceptor!(
+    fn recvmsg(sockfd: libc::c_int, msg: *mut libc::msghdr, flags: libc::c_int) -> libc::ssize_t {
+        HostNetworkState::with_socket(sockfd, |socket| -> CResult<libc::ssize_t> {
+            assert_eq!(
+                socket.ty,
+                libc::SOCK_DGRAM,
+                "only UDP is supported in recvmsg/recvmmsg"
+            );
+
+            if flags != 0 {
+                warn!("unsupported flags to sendmsg/sendmmsg: {:x}", flags);
+            }
+
+            // i'm not exactly clear what errno should be returned if you call recvmsg() without
+            // bind(), so just assert. Working code won't trigger this.
+            let ep = socket
+                .endpoint
+                .as_ref()
+                .expect("recvmsg on un-bound socket");
+
+            let udp_tag = ep.udp_tag().expect("recvmsg on un-bound socket");
+
+            let (payload, from) =
+                ep.recv_from_raw_sync(udp_tag)
+                    .map_err(|err| match err.kind() {
+                        io::ErrorKind::WouldBlock => (-1, libc::EAGAIN),
+                        _ => todo!("unhandled error case"),
+                    })?;
+
+            let msg = &mut *msg;
+
+            if !msg.msg_name.is_null() {
+                let from: socket2::SockAddr = from.into();
+                std::ptr::copy_nonoverlapping(
+                    from.as_ptr() as *const u8,
+                    msg.msg_name as *mut u8,
+                    from.len() as usize,
+                );
+            }
+
+            let payload = payload
+                .downcast::<UDPMessage>()
+                .expect("message was not UDPMessage")
+                .into_payload();
+
+            assert_eq!(msg.msg_iovlen, 1, "scatter/gather unsupported");
+
+            let iov = &*msg.msg_iov;
+            let copy_len = std::cmp::min(iov.iov_len, payload.len());
+            if copy_len < payload.len() {
+                msg.msg_flags |= libc::MSG_TRUNC;
+            }
+            std::ptr::copy_nonoverlapping(
+                payload.as_ptr() as *const u8,
+                iov.iov_base as *mut u8,
+                copy_len,
+            );
+
+            // TODO: control message
+            Ok(copy_len as libc::ssize_t)
+        })
+        .unwrap_or_else(|e| {
+            trace!("socket not found: {}", e);
+            // could also be EBADF, probably not worth trying to emulate perfectly.
+            CResult::Err((-1, libc::ENOTSOCK))
+        })
+        .unwrap_or_else(|(ret, err)| {
+            trace!("error status: {} {}", ret, err);
+            set_errno(err);
+            ret
+        })
+    }
+);
+
+#[cfg(target_os = "linux")]
+define_sys_interceptor!(
+    fn recvmmsg(
+        sockfd: libc::c_int,
+        msgvec: *mut libc::mmsghdr,
+        vlen: libc::c_uint,
+        flags: libc::c_int,
+        timeout: *mut libc::timespec,
+    ) -> libc::c_int {
+        todo!();
+    }
+);
 
 impl plugin::Simulator for NetSim {
     fn new(rand: &GlobalRng, time: &TimeHandle, config: &crate::Config) -> Self {
@@ -74,6 +551,7 @@ impl plugin::Simulator for NetSim {
             network: Mutex::new(Network::new(rand.clone(), time.clone(), config.net.clone())),
             rand: rand.clone(),
             time: time.clone(),
+            host_state: Default::default(),
             next_port_map: Mutex::new(HashMap::new()),
         }
     }
@@ -202,6 +680,21 @@ impl Endpoint {
         })
     }
 
+    /// return the tag used to send to this endpooint, for udp connections only.
+    /// (It is the same as the udp port number).
+    /// port is 0 we panic
+    pub fn udp_tag(&self) -> io::Result<u64> {
+        let port = self.addr.port();
+        if port == 0 {
+            Err(io::Error::new(
+                io::ErrorKind::NotConnected,
+                "endpoint is not bound",
+            ))
+        } else {
+            Ok(port as u64)
+        }
+    }
+
     /// Creates a [`Endpoint`] from the given address.
     pub async fn bind(addr: impl ToSocketAddrs) -> io::Result<Self> {
         let net = plugin::simulator::<NetSim>();
@@ -315,14 +808,23 @@ impl Endpoint {
     /// It is provided for use by other simulators.
     #[cfg_attr(docsrs, doc(cfg(msim)))]
     pub async fn send_to_raw(&self, dst: SocketAddr, tag: u64, data: Payload) -> io::Result<()> {
+        self.send_to_raw_sync(dst, tag, data);
+        self.net.rand_delay().await;
+        Ok(())
+    }
+
+    /// Sends a raw message.
+    ///
+    /// NOTE: Applications should not use this function!
+    /// It is provided for use by other simulators.
+    #[cfg_attr(docsrs, doc(cfg(msim)))]
+    pub fn send_to_raw_sync(&self, dst: SocketAddr, tag: u64, data: Payload) {
         trace!("send_to_raw {} -> {}, {:x}", self.addr, dst, tag);
         self.net
             .network
             .lock()
             .unwrap()
             .send(plugin::node(), self.addr, dst, tag, data);
-        self.net.rand_delay().await;
-        Ok(())
     }
 
     /// Receives a raw message.
@@ -344,6 +846,25 @@ impl Endpoint {
         self.net.rand_delay().await;
 
         trace!("recv: {} <- {}, tag={:x}", self.addr, msg.from, msg.tag);
+        Ok((msg.data, msg.from))
+    }
+
+    /// Receive a raw message, synchronously
+    pub fn recv_from_raw_sync(&self, tag: u64) -> io::Result<(Payload, SocketAddr)> {
+        let msg = self
+            .net
+            .network
+            .lock()
+            .unwrap()
+            .recv_sync(plugin::node(), self.addr, tag)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::WouldBlock, "recv call would blck"))?;
+
+        trace!(
+            "recv sync: {} <- {}, tag={:x}",
+            self.addr,
+            msg.from,
+            msg.tag
+        );
         Ok((msg.data, msg.from))
     }
 
@@ -370,6 +891,17 @@ impl Endpoint {
             "receive a message but not from the connected address"
         );
         Ok(msg)
+    }
+
+    /// Check if there is a message waiting that can be received without blocking.
+    /// If not, schedule a wakeup using the context.
+    pub fn recv_ready(&self, cx: &mut Context<'_>, tag: u64) -> io::Result<bool> {
+        Ok(self
+            .net
+            .network
+            .lock()
+            .unwrap()
+            .recv_ready(cx, plugin::node(), self.addr, tag))
     }
 }
 

--- a/msim/src/sim/net/network.rs
+++ b/msim/src/sim/net/network.rs
@@ -1,6 +1,5 @@
 use crate::{rand::*, task::NodeId, time::TimeHandle};
 use futures::channel::oneshot;
-use tracing::*;
 use serde::{Deserialize, Serialize};
 use std::{
     any::Any,
@@ -12,6 +11,7 @@ use std::{
     sync::{Arc, Mutex},
     time::Duration,
 };
+use tracing::*;
 
 /// A simulated network.
 pub(crate) struct Network {
@@ -211,7 +211,7 @@ impl Network {
         tag: u64,
         data: Payload,
     ) {
-        trace!("send: {node} {src} -> {dst}, tag={tag}");
+        trace!("send: {node} {src} -> {dst}, tag={tag:x}");
         let dst_node = if dst.ip().is_loopback() {
             node
         } else if let Some(x) = self.addr_to_node.get(&dst.ip()) {
@@ -247,6 +247,7 @@ impl Network {
         trace!("delay: {latency:?}");
         self.time
             .add_timer(self.time.now_instant() + latency, move || {
+                trace!("deliver: {node} {src} -> {dst}, tag={tag:x}");
                 ep.lock().unwrap().deliver(msg);
             });
         self.stat.msg_count += 1;

--- a/msim/src/sim/runtime/mod.rs
+++ b/msim/src/sim/runtime/mod.rs
@@ -178,8 +178,8 @@ impl Runtime {
     /// ```
     pub fn enable_determinism_check(&self, log: Option<rand::Log>) {
         assert_eq!(
-            self.task.time_handle().elapsed(),
-            Duration::default(),
+            self.task.time_handle().time_since_clock_base(),
+            Duration::from_secs(0),
             "deterministic check must be set at init"
         );
         if let Some(log) = log {

--- a/msim/src/sim/runtime/mod.rs
+++ b/msim/src/sim/runtime/mod.rs
@@ -65,6 +65,7 @@ impl Runtime {
         let rt = Runtime { rand, task, handle };
         rt.add_simulator::<fs::FsSim>();
         rt.add_simulator::<net::NetSim>();
+        intercept::enable_intercepts(true);
         rt
     }
 
@@ -124,6 +125,7 @@ impl Runtime {
     /// ```
     pub fn block_on<F: Future>(&self, future: F) -> F::Output {
         let _guard = crate::context::enter(self.handle.clone());
+        crate::time::ensure_clocks();
         self.task.block_on(future)
     }
 

--- a/msim/src/sim/time/mod.rs
+++ b/msim/src/sim/time/mod.rs
@@ -11,6 +11,7 @@ pub use std::time::Duration;
 use std::{
     future::Future,
     sync::{Arc, Mutex},
+    task::Waker,
     time::SystemTime,
 };
 
@@ -146,6 +147,11 @@ impl TimeHandle {
     ) {
         let mut timer = self.timer.lock().unwrap();
         timer.add(deadline - self.clock.base_instant(), |_| callback());
+    }
+
+    /// Schedule waker.wake() in the future.
+    pub fn wake_at(&self, deadline: Instant, waker: Waker) {
+        self.add_timer(deadline, || waker.wake());
     }
 
     // Get the elapsed time since the beginning of the test run - this should not be exposed to

--- a/msim/src/sim/utils/mpsc.rs
+++ b/msim/src/sim/utils/mpsc.rs
@@ -83,4 +83,13 @@ impl<T> Receiver<T> {
             Err(TryRecvError::Empty)
         }
     }
+
+    pub fn clear_inner(&self) {
+        let mut old = Vec::new();
+        {
+            let mut queue = self.inner.queue.lock().unwrap();
+            std::mem::swap(&mut old, &mut queue);
+        }
+        // must release lock before dropping queue.
+    }
 }


### PR DESCRIPTION
In order to support https://github.com/MystenLabs/anemo, which in turn uses https://github.com/quinn-rs/quinn, some creativity was required - quinn does not use tokio::net::UdpSocket, nor even std::net::UdpSocket, but actually does all its UDP I/O using libc::sendmsg/sendmmsg/recvmsg/recvmmsg.

In order to support this, the simulator now implements the required posix networking APIs itself, so that it can intercept socket operations and redirect them to the simulator. Using the same interception mechanism, we intercept both `mach_absolute_time` and `clock_gettime` in order to provide determinism for code (such as quinn) that uses `std::time::Instant` instead of `tokio::time::Instant`.