### PR TITLE
Add pin to the future timer sleep

### DIFF
--- a/mocked-crates/futures-timer/src/lib.rs
+++ b/mocked-crates/futures-timer/src/lib.rs
@@ -4,22 +4,24 @@ use std::task::{Context, Poll};
 use tokio::time::{sleep, Duration, Instant, Sleep};
 
 pub struct Delay {
-    inner: Sleep,
+    inner: Pin<Box<Sleep>>,
 }
 
 impl Delay {
     pub fn new(dur: Duration) -> Self {
-        Self { inner: sleep(dur) }
+        Self {
+            inner: Box::pin(sleep(dur)),
+        }
     }
 
     pub fn reset(&mut self, dur: Duration) {
-        Pin::new(&mut self.inner).reset(Instant::now() + dur);
+        self.inner.as_mut().reset(Instant::now() + dur);
     }
 }
 
 impl Future for Delay {
     type Output = ();
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        Pin::new(&mut self.inner).poll(cx)
+        self.inner.as_mut().poll(cx)
     }
 }

--- a/msim-macros/src/lib.rs
+++ b/msim-macros/src/lib.rs
@@ -415,7 +415,7 @@ fn build_test_config(args: syn::AttributeArgs) -> Result<TestConfig, syn::Error>
                         let expr = match &namevalue.lit {
                             syn::Lit::Str(litstr) => syn::parse_str::<syn::Expr>(&litstr.value())?,
                             _ => {
-                                let msg = format!("expected string literal");
+                                let msg = "expected string literal".to_string();
                                 return Err(syn::Error::new_spanned(namevalue, msg));
                             }
                         };


### PR DESCRIPTION
Without this, I get this error in simtest which is blocking my [PR](https://github.com/MystenLabs/sui/actions/runs/3958582825/jobs/6786276293) to land:
```
error[E0277]: `PhantomPinned` cannot be unpinned
  --> /home/runner/.cargo/git/checkouts/mysten-sim-6c6e892b5d19dc47/bef8815/mocked-crates/futures-timer/src/lib.rs:23:18
   |
23 |         Pin::new(&mut self.inner).poll(cx)
   |         -------- ^^^^^^^^^^^^^^^ within `tokio::time::sleep::_::__Origin<'_>`, the trait `Unpin` is not implemented for `PhantomPinned`
   |         |
   |         required by a bound introduced by this call
```
After this change, the problem goes away in local run tested with
```
 cargo test --no-run --message-format json-render-diagnostics --profile simulator --config 'build.rustflags = ["--cfg","msim"]' --config 'patch.crates-io.tokio.git = "https://github.com/MystenLabs/mysten-sim.git"' --config 'patch.crates-io.tokio.rev = "bef88159c02fae45d94739f4d380efebf86b2958"' --config 'patch.crates-io.futures-timer.path = "/Users/sadhansood/dev/mysten-sim/mocked-crates/futures-timer"'
```