### PR TITLE
Add AsFd impl for msim `UdpSocket`.

### DIFF
--- a/msim-tokio/src/sim/udp.rs
+++ b/msim-tokio/src/sim/udp.rs
@@ -1,7 +1,7 @@
 use std::{
     io, net,
     net::{Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs},
-    os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd},
+    os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd},
     sync::{Arc, Mutex},
     task::{Context, Poll},
 };
@@ -288,6 +288,12 @@ impl UdpSocket {
 impl AsRawFd for UdpSocket {
     fn as_raw_fd(&self) -> RawFd {
         self.fd.as_raw_fd()
+    }
+}
+
+impl AsFd for UdpSocket {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.fd.as_fd()
     }
 }
 

--- a/msim/src/sim/net/mod.rs
+++ b/msim/src/sim/net/mod.rs
@@ -39,7 +39,7 @@ use std::{
     collections::{hash_map::Entry, HashMap, HashSet},
     io,
     net::{IpAddr, Ipv4Addr, SocketAddr, ToSocketAddrs},
-    os::unix::io::{AsRawFd, RawFd},
+    os::unix::io::{AsFd, AsRawFd, BorrowedFd, RawFd},
     sync::{Arc, Mutex},
     task::Context,
 };
@@ -104,6 +104,12 @@ impl OwnedFd {
 impl AsRawFd for OwnedFd {
     fn as_raw_fd(&self) -> RawFd {
         self.0
+    }
+}
+
+impl AsFd for OwnedFd {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        unsafe { BorrowedFd::borrow_raw(self.as_raw_fd()) }
     }
 }
 


### PR DESCRIPTION
Required for current version of quinn.