### PR TITLE
Add AsFd implementation for TcpStream; Allocate tcp id per node instead of per address.

### DIFF
--- a/msim-tokio/src/sim/net.rs
+++ b/msim-tokio/src/sim/net.rs
@@ -4,7 +4,7 @@ use std::{
     future::Future,
     io,
     net::SocketAddr as StdSocketAddr,
-    os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd},
+    os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd},
     pin::Pin,
     sync::{
         atomic::{AtomicBool, AtomicU32, Ordering},
@@ -774,6 +774,12 @@ impl FromRawFd for TcpStream {
 impl IntoRawFd for TcpStream {
     fn into_raw_fd(self) -> RawFd {
         unimplemented!("into_raw_fd not supported in simulator")
+    }
+}
+
+impl AsFd for TcpStream {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        unimplemented!("as_fd not supported in simulator")
     }
 }
 

--- a/msim/src/sim/net/mod.rs
+++ b/msim/src/sim/net/mod.rs
@@ -70,7 +70,7 @@ pub struct NetSim {
     host_state: Mutex<HostNetworkState>,
     rand: GlobalRng,
     time: TimeHandle,
-    next_tcp_id_map: Mutex<HashMap<IpAddr, u32>>,
+    next_tcp_id_map: Mutex<HashMap<NodeId, u32>>,
 }
 
 #[derive(Debug)]
@@ -991,13 +991,13 @@ impl NetSim {
         self.time.sleep(delay).await;
     }
 
-    /// Get the next unused tcp id for this ip address.
-    pub fn next_tcp_id(&self, ip: IpAddr) -> u32 {
+    /// Get the next unused tcp id for this node.
+    pub fn next_tcp_id(&self, node: NodeId) -> u32 {
         let mut map = self.next_tcp_id_map.lock().unwrap();
-        match map.entry(ip) {
+        match map.entry(node) {
             Entry::Occupied(mut cur) => {
                 let cur = cur.get_mut();
-                // limited to 2^32 - 1 tcp sessions per ip per simulation run.
+                // limited to 2^32 - 1 tcp sessions per node per simulation run.
                 *cur = cur.checked_add(1).unwrap();
                 *cur
             }
@@ -1111,7 +1111,13 @@ impl Endpoint {
 
     /// Allocate a new tcp id number for this node. Ids are never reused.
     pub fn allocate_local_tcp_id(&self) -> u32 {
-        let id = self.net.next_tcp_id(self.addr.ip());
+        let id = self.net.next_tcp_id(self.node);
+        trace!(
+            "Allocate local tcp id {} to node {} address {}",
+            id,
+            self.node,
+            self.addr.ip()
+        );
         self.live_tcp_ids.lock().unwrap().insert(id);
         self.net
             .network


### PR DESCRIPTION
- Add AsFd implementation for TcpStream, although not used, it is required by hyper-0.14.28
- Allocate tcp id per node instead of per address. Due to various different clients uses, it may allocate multiple addresses per node. Allocate tcp id per address may cause id collision.