### PR TITLE
[cargo.toml] fix typo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
     "test-crates/jsonrpsee-test",
 ]
 
-[lints.rust]
+[workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
   'cfg(msim)',
 ] }


### PR DESCRIPTION
This has been blocking rust-analyzer from running on this repo.