### PR TITLE
chore: support APIs used by tokio-util 0.7.17+

### DIFF
--- a/msim-tokio/Cargo.toml
+++ b/msim-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio"
-version = "1.47.1"
+version = "1.49.0"
 edition = "2021"
 authors = ["Runji Wang <wangrunji0408@163.com>", "Mysten Labs <build@mystenlabs.com>"]
 description = "The `tokio` simulator on msim."
@@ -47,12 +47,9 @@ test-util = ["real_tokio/test-util"]
 tracing = ["real_tokio/tracing"]
 bytes = ["real_tokio/bytes"]
 libc = ["real_tokio/libc"]
-memchr = ["real_tokio/memchr"]
 mio = ["real_tokio/mio"]
-num_cpus = ["real_tokio/num_cpus"]
 signal-hook-registry = ["real_tokio/signal-hook-registry"]
 socket2 = ["real_tokio/socket2"]
-stats = ["real_tokio/stats"]
 tokio-macros = ["real_tokio/tokio-macros"]
 
 [target.'cfg(msim)'.dependencies]
@@ -61,7 +58,7 @@ msim = { version = "0.1.0", path = "../msim" }
 [dependencies]
 tracing = "0.1"
 
-real_tokio = { git = "https://github.com/MystenLabs/tokio-msim-fork.git", rev = "c59702c3177a31405d42ec12e01fa4a445728326", package = "real_tokio", features = ["full"] }
+real_tokio = { git = "https://github.com/MystenLabs/tokio-msim-fork.git", rev = "6b1da10b18f9a4b1d42b1432415a0b3092908c77", package = "real_tokio", features = ["full"] }
 bytes = { version = "1.1" }
 futures = { version = "0.3.0", features = ["async-await"] }
 mio = { version = "0.8.1", features = ["net"] }

--- a/msim/Cargo.toml
+++ b/msim/Cargo.toml
@@ -38,8 +38,8 @@ ahash = "0.7"
 downcast-rs = "1.2"
 libc = "0.2"
 naive-timer = "0.2"
-tokio = { git = "https://github.com/MystenLabs/tokio-msim-fork.git", rev = "c59702c3177a31405d42ec12e01fa4a445728326", package = "real_tokio", features = ["full"] }
-tokio-util = { git = "https://github.com/MystenLabs/tokio-msim-fork.git", rev = "c59702c3177a31405d42ec12e01fa4a445728326", features = ["full"] }
+tokio = { git = "https://github.com/MystenLabs/tokio-msim-fork.git", rev = "6b1da10b18f9a4b1d42b1432415a0b3092908c77" , package = "real_tokio", features = ["full"] }
+tokio-util = { git = "https://github.com/MystenLabs/tokio-msim-fork.git", rev = "6b1da10b18f9a4b1d42b1432415a0b3092908c77", features = ["full"] }
 toml = "0.5"
 socket2 = "0.4"
 erasable = "1.2"
@@ -50,7 +50,7 @@ async-task = { git = "https://github.com/mystenmark/async-task", rev = "4e45b26e
 [dev-dependencies]
 criterion = "0.3"
 structopt = "0.3"
-tokio = { git = "https://github.com/MystenLabs/tokio-msim-fork.git", rev = "c59702c3177a31405d42ec12e01fa4a445728326", package = "real_tokio", features = ["full"] }
+tokio = { git = "https://github.com/MystenLabs/tokio-msim-fork.git", rev = "6b1da10b18f9a4b1d42b1432415a0b3092908c77", package = "real_tokio", features = ["full"] }
 
 [[bench]]
 name = "rpc"

--- a/msim/src/sim/task.rs
+++ b/msim/src/sim/task.rs
@@ -29,7 +29,9 @@ use std::{
 
 use tracing::{error_span, info, trace, Span};
 
+pub use tokio::msim_adapter::runtime_task::Id;
 pub use tokio::msim_adapter::{join_error, runtime_task};
+pub use tokio::task::coop;
 pub use tokio::task::{yield_now, JoinError};
 pub use tokio::{select, sync::watch};
 
@@ -610,11 +612,17 @@ impl<T> InnerHandle<T> {
 /// An owned permission to join on a task (await its termination).
 #[derive(Debug)]
 pub struct JoinHandle<T> {
-    id: runtime_task::Id,
+    id: Id,
     inner: Arc<InnerHandle<T>>,
 }
 
 impl<T> JoinHandle<T> {
+    /// Returns a task ID that uniquely identifies this task relative to other currently spawned
+    /// tasks.
+    pub fn id(&self) -> Id {
+        self.id
+    }
+
     /// Abort the task associated with the handle.
     pub fn abort(&self) {
         self.inner.abort();
@@ -668,7 +676,7 @@ impl<T> Drop for JoinHandle<T> {
 
 /// AbortHandle allows aborting, but not awaiting the return value.
 pub struct AbortHandle {
-    id: runtime_task::Id,
+    id: Id,
     inner: ErasedPtr,
 }
 

--- a/msim/src/sim/task/join_set.rs
+++ b/msim/src/sim/task/join_set.rs
@@ -56,6 +56,14 @@ impl<T: 'static> JoinSet<T> {
         self.insert(crate::task::spawn(task))
     }
 
+    pub fn spawn_blocking<F>(&mut self, task: F) -> AbortHandle
+    where
+        F: FnOnce() -> T + Send + 'static,
+        T: Send + 'static,
+    {
+        self.insert(crate::task::spawn_blocking(task))
+    }
+
     pub fn spawn_local<F>(&mut self, task: F) -> AbortHandle
     where
         F: Future<Output = T>,


### PR DESCRIPTION
## Descripion

This is required to unblock the removal of `rustls-pemfile` as a dependency in the `sui` mono-repo:

- `rustls-pemfile` is a dependency of `object_store` < 0.13, requiring we bump our dependency on `object_store`.
- `object_store` >= 0.13 requires `tokio-util` >= 0.7.17.
- `tokio-util` >= 0.7.17 makes references to `JoinHandle::id()`, `tokio::task::coop`, and `JoinSet::spawn_blocking`.

## Test plan

```
sui$ LOCAL_MSIM_PATH=... cargo simtest --no-run
```

+ CI