### PR TITLE
tokio: make TcpListener::accept cancellation-safe

### DIFF
--- a/msim-tokio/src/sim/net.rs
+++ b/msim-tokio/src/sim/net.rs
@@ -83,7 +83,7 @@ impl TcpListener {
     }
 
     pub async fn accept(&self) -> io::Result<(TcpStream, StdSocketAddr)> {
-        Self::poll_accept_internal(self.ep.clone()).await
+        std::future::poll_fn(|cx| self.poll_accept(cx)).await
     }
 
     async fn poll_accept_internal(ep: Arc<Endpoint>) -> io::Result<(TcpStream, StdSocketAddr)> {


### PR DESCRIPTION
## Summary

Make `TcpListener::accept` cancel-safe by routing it through `poll_accept`, so an in-flight accept is preserved across cancellation of the awaiting future. This matches tokio's documented cancel-safety guarantee for `tokio::net::TcpListener::accept`.

## Background

The previous implementation awaited `poll_accept_internal` directly:

```rust
pub async fn accept(&self) -> io::Result<(TcpStream, StdSocketAddr)> {
    Self::poll_accept_internal(self.ep.clone()).await
}
```

Each call constructed a fresh future. If the caller dropped the `accept()` future mid-await (e.g. inside a `tokio::select!`), the in-flight future was destroyed — losing progress at intermediate `.await` points in `poll_accept_internal`, which has multiple suspension points:

1. `ep.recv_from_raw(0).await` — consumes the client's TCP id message
2. `ep.allocate_local_tcp_id()` — allocates listener-side state
3. `state.ep.send_to_raw(...).await` — replies with the local id

Cancelling between (1) and (3) consumed an inbound message and allocated id state that the client never learned about, leaving the connection half-open from the client's perspective.

## Change

```rust
pub async fn accept(&self) -> io::Result<(TcpStream, StdSocketAddr)> {
    std::future::poll_fn(|cx| self.poll_accept(cx)).await
}
```

`poll_accept` already stores its in-flight future inside `self.poller` (an `Arc<Mutex<Option<Pin<Box<...>>>>>`), so cancelling the outer `accept()` only drops the `poll_fn` wrapper — the inner future remains in the listener and is resumed on the next `accept()` call.

## Notes

- No new allocations or locking on the success path beyond what `poll_accept` already did; this just makes `accept` use the same path.
- Determinism is preserved: the `Poller`'s `Mutex` has no contention under msim's single-threaded executor, and wake/poll ordering is unchanged.
- `Poller` was previously unused by `accept` itself and only reachable via direct calls to `poll_accept`; this unifies both entry points.

## Test plan

- [ ] Existing tests pass
- [ ] Add a test that drops an in-flight `accept()` future and verifies a subsequent `accept()` completes the same logical connection
