### PR TITLE
Drop teardown-time futures with intercepts disabled

### DIFF
--- a/msim/src/sim/intercept.rs
+++ b/msim/src/sim/intercept.rs
@@ -53,6 +53,27 @@ impl Drop for InterceptsGuard {
     }
 }
 
+/// Disable intercepts on the current thread for the lifetime of the returned guard,
+/// restoring the previous setting on drop. The inverse of [`enable_intercepts_scoped`].
+///
+/// This is for narrow teardown windows that must let a specific set of late syscalls
+/// (e.g. from a resource's `Drop`) reach the real libc. It intentionally does not make
+/// the interceptors globally tolerant of a missing reactor - an intercepted syscall with
+/// no simulation context anywhere else is a real bug we want to keep surfacing loudly.
+pub(crate) fn disable_intercepts_scoped() -> InterceptsRestoreGuard {
+    let previous = intercepts_enabled();
+    enable_intercepts_quiet(false);
+    InterceptsRestoreGuard(previous)
+}
+
+pub(crate) struct InterceptsRestoreGuard(bool);
+
+impl Drop for InterceptsRestoreGuard {
+    fn drop(&mut self) {
+        enable_intercepts_quiet(self.0);
+    }
+}
+
 /// Cache and call a library function via dlsym()
 #[macro_export]
 macro_rules! define_sys_interceptor {

--- a/msim/src/sim/task.rs
+++ b/msim/src/sim/task.rs
@@ -463,6 +463,18 @@ impl Executor {
 impl Drop for Executor {
     fn drop(&mut self) {
         self.handle.blocking.shutdown();
+
+        // Runnables parked by `pause()` sit in `Node::paused` until the node map is
+        // dropped. That map is shared with `runtime::Handle`, so it outlives the executor
+        // and is torn down on the main thread after `block_on` has returned and the
+        // context is gone. Dropping a runnable drops its future, whose Drop impls can make
+        // intercepted syscalls (e.g. closing a socket or file); those would reach
+        // `context::current()` with no reactor and panic inside an `extern "C"` fn, which
+        // cannot unwind and aborts the process. Drain the map here with intercepts
+        // disabled so the late syscalls reach the real libc. Same reasoning as
+        // `PoolShared::drop`; the interceptors stay strict everywhere else.
+        let _no_intercepts = crate::sim::intercept::disable_intercepts_scoped();
+        self.handle.nodes.lock().unwrap().clear();
     }
 }
 

--- a/msim/src/sim/task/blocking.rs
+++ b/msim/src/sim/task/blocking.rs
@@ -153,6 +153,21 @@ struct PoolShared {
     num_threads: u32,
 }
 
+impl Drop for PoolShared {
+    fn drop(&mut self) {
+        // Jobs enqueued but never run are dropped here. Their closures can own resources
+        // (e.g. a RocksDB handle) whose `Drop` makes intercepted syscalls like `close`.
+        // PoolShared is dropped from `Executor::drop`, on the main thread, after the
+        // reactor context is gone - so such a syscall would reach `context::current()`
+        // and panic ("no reactor running"), aborting the process. Drain the queue with
+        // intercepts disabled so those late syscalls go to the real libc. We restore the
+        // prior setting afterwards rather than relaxing the interceptors globally: a
+        // context-less intercepted syscall anywhere else is still a bug worth surfacing.
+        let _no_intercepts = crate::sim::intercept::disable_intercepts_scoped();
+        self.queue.clear_inner();
+    }
+}
+
 pub(crate) struct BlockingPool {
     shared: Arc<PoolShared>,
     threads: Mutex<Vec<std::thread::JoinHandle<()>>>,

--- a/msim/tests/teardown_drop.rs
+++ b/msim/tests/teardown_drop.rs
@@ -1,0 +1,120 @@
+// The simulator API only exists under `--cfg msim`; without it this file compiles to an
+// empty crate rather than failing to resolve `msim::runtime`.
+#![cfg(msim)]
+
+//! Regression tests for futures dropped during runtime teardown.
+//!
+//! After `block_on` returns, the runtime context is gone but intercepts are still enabled
+//! on the test thread (`Runtime::with_seed_and_config` turns them on and never turns them
+//! off). Anything still holding a future at that point drops it in that state, and the
+//! future's Drop impls can make intercepted syscalls - `close` on a file or socket routes
+//! through `plugin::simulator()`/`plugin::node()`, both of which panic with "there is no
+//! reactor running". The panic happens inside an `extern "C"` fn, so it aborts the process
+//! instead of failing the test.
+//!
+//! Each test below parks a future owning a `File` somewhere the executor must tear down.
+//! An abort here is a real failure even though it cannot be caught - run under nextest,
+//! which gives each test its own process.
+
+use msim::runtime::{Handle, Runtime};
+use msim::time::sleep;
+use std::fs::File;
+use std::time::Duration;
+
+fn open_fd() -> File {
+    File::open("/dev/null").expect("open /dev/null")
+}
+
+/// Baseline: dropping the file inside the runtime, with a context entered, is fine. If
+/// this aborts, the harness is broken rather than the runtime.
+#[test]
+fn drop_inside_runtime() {
+    let rt = Runtime::new();
+    rt.block_on(async {
+        let f = open_fd();
+        sleep(Duration::from_millis(1)).await;
+        drop(f);
+    });
+}
+
+/// A runnable parked in `Node::paused` by `pause()` is dropped when the node map is torn
+/// down, which happens after the context is gone. Aborted before `Executor::drop` learned
+/// to drain the map with intercepts disabled.
+#[test]
+fn paused_runnable_dropped_at_teardown() {
+    let rt = Runtime::new();
+    let node = rt.create_node().build();
+    let node_id = node.id();
+    node.spawn(async move {
+        let _f = open_fd();
+        loop {
+            sleep(Duration::from_millis(1)).await;
+        }
+    });
+    rt.block_on(async move {
+        sleep(Duration::from_millis(10)).await;
+        Handle::current().pause(node_id);
+        // let the task's timer fire while paused, parking its runnable
+        sleep(Duration::from_millis(50)).await;
+    });
+    drop(rt);
+}
+
+/// A task woken by the main future's last action is still drained by `run_all_ready`,
+/// because the main task itself runs inside that drain loop. Guards the ordering in
+/// `Executor::block_on` that makes this true.
+#[test]
+fn task_woken_as_main_future_completes() {
+    let rt = Runtime::new();
+    let node = rt.create_node().build();
+    let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+    node.spawn(async move {
+        let _f = open_fd();
+        let _ = rx.await;
+    });
+    rt.block_on(async move {
+        sleep(Duration::from_millis(10)).await;
+        // wake it and return without yielding again
+        let _ = tx.send(());
+    });
+    drop(rt);
+}
+
+/// Jobs enqueued on the blocking pool but never dequeued are dropped by `PoolShared::drop`,
+/// from `Executor::drop`, after the context is gone. This is the case that showed up as
+/// ~38 `sui-adapter-transactional-tests` aborting on a RocksDB handle's `close()`; the fd
+/// here stands in for that handle. The main future enqueues and returns in the same poll,
+/// so `block_on` exits before any wake round can dequeue them.
+#[test]
+fn unrun_blocking_job_dropped_at_teardown() {
+    let rt = Runtime::new();
+    rt.block_on(async {
+        for _ in 0..64 {
+            let f = open_fd();
+            let handle = msim::task::spawn_blocking(move || drop(f));
+            // keep the job queued rather than cancelling it via the handle
+            std::mem::forget(handle);
+        }
+    });
+    drop(rt);
+}
+
+/// `Executor::drop` shuts the blocking pool down before dropping the ready queue, so a
+/// pool thread joining at that moment can wake an async waiter. Guards that the waiter's
+/// runnable does not end up dropped context-less.
+#[test]
+fn waiter_woken_by_blocking_pool_shutdown() {
+    let rt = Runtime::new();
+    let node = rt.create_node().build();
+    node.spawn(async move {
+        let _f = open_fd();
+        let h = msim::task::spawn_blocking(|| {
+            std::thread::sleep(std::time::Duration::from_millis(300));
+        });
+        let _ = h.await;
+    });
+    rt.block_on(async {
+        sleep(Duration::from_millis(1)).await;
+    });
+    drop(rt);
+}


### PR DESCRIPTION
## What

Two teardown sites drop user futures on the main thread after `block_on` has returned and the reactor context is gone: the blocking pool's un-run jobs, and runnables parked in `Node::paused` by `pause()`. Drain both with syscall intercepts disabled, so resources captured by those futures close through the real libc.

## Why

A dropped future runs the `Drop` impls of everything it holds. Those can make an intercepted syscall — `close()` on a file or socket routes through `plugin::simulator()`/`plugin::node()`, which reach `context::current()` with no reactor and panic ("there is no reactor running"). The panic is inside an `extern "C"` fn, so it cannot unwind and aborts the process.

**Blocking pool.** A job enqueued but never run is dropped when `PoolShared` is dropped, from `Executor::drop`. This surfaced as ~38 `sui-adapter-transactional-tests` aborting with SIGABRT once a sui workspace pinned this repo's blocking-pool revision; the stack was `PoolShared` drop → un-run job closure → sui `IndexStore` → `Arc<RocksDB>` → `rocksdb_close` → `close()` → interceptor → panic.

**Paused runnables.** `pause()` parks a node's woken runnables in `Node::paused`. The node map is shared with `runtime::Handle`, so it outlives the executor and is torn down after the context is gone. Same abort, reached from a different direction. No current sui caller uses `pause()`, so this one is latent rather than observed — but it is a headache to debug when it does fire, and the fix is the same one line.

The interceptors are left strict otherwise (a scoped disable that restores the prior setting) rather than made globally tolerant of a missing reactor — a context-less intercepted syscall anywhere else is still a real bug worth surfacing.

## Test plan

`msim/tests/teardown_drop.rs` parks a future owning a `File` at each teardown site and drops the runtime; `File::drop` calls the intercepted `close()`. Run under nextest so each test gets its own process — an abort cannot be caught.

- `unrun_blocking_job_dropped_at_teardown` and `paused_runnable_dropped_at_teardown` are the regression tests, one per site. Each was verified by reverting its own fix and re-running: both SIGABRT without it, pass with it.
- `task_woken_as_main_future_completes` and `waiter_woken_by_blocking_pool_shutdown` pass both before and after. They are guards, not reproductions: the ready queue is not a hazard because the main task runs *inside* `run_all_ready`'s drain loop, so anything its completion schedules is still run with a context; and a waiter woken by pool shutdown unwinds on the pool thread, which has its own guard.
- Futures parked on the timer wheel are deliberately not covered. They are leaked rather than dropped at teardown (`Arc::strong_count` is still 2 after `drop(rt)`, with zero `Drop` calls), so they run no user code and are not a hazard. That leak looks worth a separate look, but it is not this PR.

The file is gated on `cfg(msim)`; `cargo test` without it builds the std path, where the simulator API does not exist. Full suite: 40/40 pass under `--cfg msim`, std mode builds clean. Sui `cargo simtest --test simtest` (sui-benchmark) against this branch: 34/34 pass, and the transactional tests that originally aborted now pass instead of SIGABRT.
